### PR TITLE
Handle missing AWSServiceRoleForAccessAnalyzer

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -15,6 +15,7 @@ data "external" "secret_value" {
   ]
 }
 
-data "aws_iam_role" "accessanalyzer" {
-  name = "AWSServiceRoleForAccessAnalyzer"
+data "aws_iam_roles" "access-analyzer" {
+  name_regex  = "AWSServiceRoleForAccessAnalyzer"
+  path_prefix = "/aws-service-role/access-analyzer.amazonaws.com/"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
-black ~=25.1
-boto3 ~= 1.26
-botocore ~= 1.26
-infrahouse-toolkit ~= 2.0
-myst-parser ~=4.0
-pytest-timeout ~= 2.1
-pytest-rerunfailures ~=15.1
-requests ~= 2.31
+infrahouse-core ~= 0.17
+pytest-infrahouse ~= 0.9

--- a/test_data/secret/datasources.tf
+++ b/test_data/secret/datasources.tf
@@ -1,1 +1,5 @@
 data "aws_caller_identity" "this" {}
+data "aws_iam_roles" "sso-admin" {
+  name_regex  = "AWSReservedSSO_AWSAdministratorAccess_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}

--- a/test_data/secret/main.tf
+++ b/test_data/secret/main.tf
@@ -3,12 +3,15 @@ module "test" {
   secret_description = "Foo description"
   secret_name        = var.secret_name
   secret_name_prefix = var.secret_name_prefix
-  admins             = var.admins
-  writers            = var.writers
-  readers            = var.readers
-  secret_value       = var.secret_value == "generate" ? random_password.value.result : var.secret_value
-  tags               = var.tags
-  environment        = "development"
+  admins = concat(
+    tolist(data.aws_iam_roles.sso-admin.arns),
+    var.admins
+  )
+  writers      = var.writers
+  readers      = var.readers
+  secret_value = var.secret_value == "generate" ? random_password.value.result : var.secret_value
+  tags         = var.tags
+  environment  = "development"
 }
 
 resource "random_password" "value" {

--- a/test_data/secret/variables.tf
+++ b/test_data/secret/variables.tf
@@ -1,9 +1,9 @@
 variable "region" {}
 variable "role_arn" {}
 
-variable "admins" { default = null }
-variable "writers" { default = null }
-variable "readers" { default = null }
+variable "admins" { default = [] }
+variable "writers" { default = [] }
+variable "readers" { default = [] }
 variable "secret_name" {
   default = "foo"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,125 +8,41 @@ from os import path as osp
 from infrahouse_toolkit.logging import setup_logging
 from infrahouse_toolkit.terraform import terraform_apply
 
-# "303467602807" is our test account
-TEST_ACCOUNT = "303467602807"
-TEST_ROLE_ARN = "arn:aws:iam::303467602807:role/secret-tester"
+# TEST_ROLE_ARN = "arn:aws:iam::303467602807:role/secret-tester"
 DEFAULT_PROGRESS_INTERVAL = 10
-TRACE_TERRAFORM = False
-UBUNTU_CODENAME = "jammy"
 
 LOG = logging.getLogger(__name__)
-REGION = "us-east-2"
-TEST_ZONE = "ci-cd.infrahouse.com"
 TERRAFORM_ROOT_DIR = "test_data"
 
 
 setup_logging(LOG, debug=True)
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--keep-after",
-        action="store_true",
-        default=False,
-        help="If specified, don't destroy resources.",
-    )
-    parser.addoption(
-        "--test-role-arn",
-        action="store",
-        default=TEST_ROLE_ARN,
-        help=f"AWS IAM role ARN that will create resources. Default, {TEST_ROLE_ARN}",
-    )
-
-
-@pytest.fixture(scope="session")
-def keep_after(request):
-    return request.config.getoption("--keep-after")
-
-
-@pytest.fixture(scope="session")
-def test_role_arn(request):
-    return request.config.getoption("--test-role-arn")
-
-
-@pytest.fixture(scope="session")
-def aws_iam_role():
-    sts = boto3.client("sts")
-    return sts.assume_role(
-        RoleArn=TEST_ROLE_ARN, RoleSessionName=TEST_ROLE_ARN.split("/")[1]
-    )
-
-
-@pytest.fixture(scope="session")
-def boto3_session(aws_iam_role):
-    return boto3.Session(
-        aws_access_key_id=aws_iam_role["Credentials"]["AccessKeyId"],
-        aws_secret_access_key=aws_iam_role["Credentials"]["SecretAccessKey"],
-        aws_session_token=aws_iam_role["Credentials"]["SessionToken"],
-    )
-
-
-@pytest.fixture(scope="session")
-def ec2_client(boto3_session):
-    assert boto3_session.client("sts").get_caller_identity()["Account"] == TEST_ACCOUNT
-    return boto3_session.client("ec2", region_name=REGION)
-
-
-@pytest.fixture(scope="session")
-def ec2_client_map(ec2_client, boto3_session):
-    regions = [reg["RegionName"] for reg in ec2_client.describe_regions()["Regions"]]
-    ec2_map = {reg: boto3_session.client("ec2", region_name=reg) for reg in regions}
-
-    return ec2_map
-
-
-@pytest.fixture()
-def route53_client(boto3_session):
-    return boto3_session.client("route53", region_name=REGION)
-
-
-@pytest.fixture()
-def elbv2_client(boto3_session):
-    return boto3_session.client("elbv2", region_name=REGION)
-
-
-@pytest.fixture()
-def autoscaling_client(boto3_session):
-    assert boto3_session.client("sts").get_caller_identity()["Account"] == TEST_ACCOUNT
-    return boto3_session.client("autoscaling", region_name=REGION)
-
-
-@pytest.fixture()
-def secretsmanager_client(boto3_session):
-    assert boto3_session.client("sts").get_caller_identity()["Account"] == TEST_ACCOUNT
-    return boto3_session.client("secretsmanager", region_name=REGION)
-
-
-def get_secretsmanager_client_by_role(role_name):
+def get_secretsmanager_client_by_role(role_name, test_role_arn, region):
     response = boto3.client("sts").assume_role(
-        RoleArn=role_name, RoleSessionName=TEST_ROLE_ARN.split("/")[1]
+        RoleArn=role_name, RoleSessionName=test_role_arn.split("/")[1]
     )
     # noinspection PyUnresolvedReferences
     return boto3.Session(
         aws_access_key_id=response["Credentials"]["AccessKeyId"],
         aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
         aws_session_token=response["Credentials"]["SessionToken"],
-    ).client("secretsmanager", region_name=REGION)
+    ).client("secretsmanager", region_name=region)
 
 
 @pytest.fixture()
-def probe_role(boto3_session, keep_after):
+def probe_role(boto3_session, keep_after, test_role_arn, aws_region):
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "probe_role")
     # Create service network
     with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:
         fp.write(
             dedent(
                 f"""
-                role_arn     = "{TEST_ROLE_ARN}"
-                region       = "{REGION}"
+                role_arn     = "{test_role_arn}"
+                region       = "{aws_region}"
                 trusted_arns = [
                     "arn:aws:iam::990466748045:user/aleks",
-                    "{TEST_ROLE_ARN}"
+                    "{test_role_arn}"
                 ]
                 """
             )
@@ -135,6 +51,5 @@ def probe_role(boto3_session, keep_after):
         terraform_module_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         yield tf_output

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,5 +1,6 @@
 import json
 from os import path as osp
+from pprint import pprint
 from textwrap import dedent
 
 import pytest
@@ -8,26 +9,23 @@ from infrahouse_toolkit.terraform import terraform_apply
 
 from tests.conftest import (
     LOG,
-    TRACE_TERRAFORM,
-    REGION,
     TERRAFORM_ROOT_DIR,
     get_secretsmanager_client_by_role,
 )
 
 
 @pytest.mark.parametrize("probe_role_suffix", ["", "*"])
-def test_module(probe_role, keep_after, test_role_arn, probe_role_suffix):
+def test_module(probe_role, keep_after, test_role_arn, probe_role_suffix, aws_region):
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "secret")
     probe_role_arn = probe_role["role_arn"]["value"]
     with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:
         fp.write(
             dedent(
                 f"""
-                region = "{REGION}"
+                region = "{aws_region}"
                 role_arn = "{test_role_arn}"
 
                 admins = [
-                    "arn:aws:iam::303467602807:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_422821c726d81c14",
                     "{probe_role_arn}{probe_role_suffix}"
                 ]
                 """
@@ -38,23 +36,23 @@ def test_module(probe_role, keep_after, test_role_arn, probe_role_suffix):
         terraform_module_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
 
 
-def test_module_no_access(probe_role, secretsmanager_client, keep_after, test_role_arn):
+def test_module_no_access(
+    probe_role, secretsmanager_client, keep_after, test_role_arn, aws_region
+):
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "secret")
     probe_role_arn = probe_role["role_arn"]["value"]
     with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:
         fp.write(
             dedent(
                 f"""
-                region = "{REGION}"
+                region = "{aws_region}"
                 role_arn = "{test_role_arn}"
 
                 admins = [
-                    "arn:aws:iam::303467602807:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_422821c726d81c14",
                     "{test_role_arn}"
                 ]
                 """
@@ -65,10 +63,11 @@ def test_module_no_access(probe_role, secretsmanager_client, keep_after, test_ro
         terraform_module_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
-        sm_client = get_secretsmanager_client_by_role(probe_role_arn)
+        sm_client = get_secretsmanager_client_by_role(
+            probe_role_arn, test_role_arn, aws_region
+        )
         with pytest.raises(ClientError) as err:
             sm_client.get_secret_value(
                 SecretId="foo",
@@ -89,7 +88,12 @@ def test_module_no_access(probe_role, secretsmanager_client, keep_after, test_ro
 
 @pytest.mark.parametrize("probe_role_suffix", ["", "*"])
 def test_module_reads(
-    probe_role, secretsmanager_client, keep_after, test_role_arn, probe_role_suffix
+    probe_role,
+    secretsmanager_client,
+    keep_after,
+    test_role_arn,
+    probe_role_suffix,
+    aws_region,
 ):
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "secret")
     probe_role_arn = probe_role["role_arn"]["value"]
@@ -97,11 +101,10 @@ def test_module_reads(
         fp.write(
             dedent(
                 f"""
-                region = "{REGION}"
+                region = "{aws_region}"
                 role_arn = "{test_role_arn}"
 
                 admins = [
-                    "arn:aws:iam::303467602807:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_422821c726d81c14",
                     "{test_role_arn}"
                 ]
                 readers = [
@@ -115,10 +118,11 @@ def test_module_reads(
         terraform_module_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
-        sm_client = get_secretsmanager_client_by_role(probe_role["role_arn"]["value"])
+        sm_client = get_secretsmanager_client_by_role(
+            probe_role["role_arn"]["value"], test_role_arn, aws_region
+        )
         # Can read
         assert (
             sm_client.get_secret_value(
@@ -139,7 +143,12 @@ def test_module_reads(
 
 @pytest.mark.parametrize("probe_role_suffix", ["", "*"])
 def test_module_writes(
-    probe_role, secretsmanager_client, keep_after, test_role_arn, probe_role_suffix
+    probe_role,
+    secretsmanager_client,
+    keep_after,
+    test_role_arn,
+    probe_role_suffix,
+    aws_region,
 ):
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "secret")
     probe_role_arn = probe_role["role_arn"]["value"]
@@ -147,11 +156,10 @@ def test_module_writes(
         fp.write(
             dedent(
                 f"""
-                region = "{REGION}"
+                region = "{aws_region}"
                 role_arn = "{test_role_arn}"
 
                 admins = [
-                    "arn:aws:iam::303467602807:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_422821c726d81c14",
                     "{test_role_arn}"
                 ]
                 writers = [
@@ -165,10 +173,11 @@ def test_module_writes(
         terraform_module_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
-        sm_client = get_secretsmanager_client_by_role(probe_role["role_arn"]["value"])
+        sm_client = get_secretsmanager_client_by_role(
+            probe_role["role_arn"]["value"], test_role_arn, aws_region
+        )
 
         # Can read
         assert (
@@ -197,18 +206,16 @@ def test_module_writes(
         assert err.value.response["Error"]["Code"] == "AccessDeniedException"
 
 
-def test_module_secret_value(probe_role, keep_after, test_role_arn):
+def test_module_secret_value(probe_role, keep_after, test_role_arn, aws_region):
     probe_role_arn = probe_role["role_arn"]["value"]
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "secret")
     with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:
         fp.write(
             dedent(
                 f"""
-                region = "{REGION}"
+                region = "{aws_region}"
                 role_arn = "{test_role_arn}"
-                admins = [
-                    "arn:aws:iam::303467602807:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_422821c726d81c14",
-                ]
+                admins = []
 
                 writers = [
                     "{probe_role_arn}"
@@ -222,12 +229,13 @@ def test_module_secret_value(probe_role, keep_after, test_role_arn):
         terraform_module_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
 
         secret_value_0 = tf_output["secret_value"]["value"]
-        sm_client = get_secretsmanager_client_by_role(probe_role_arn)
+        sm_client = get_secretsmanager_client_by_role(
+            probe_role_arn, test_role_arn, aws_region
+        )
         # Can read
         assert (
             sm_client.get_secret_value(
@@ -246,9 +254,10 @@ def test_module_secret_value(probe_role, keep_after, test_role_arn):
             terraform_module_dir,
             destroy_after=not keep_after,
             json_output=True,
-            enable_trace=TRACE_TERRAFORM,
         ):
-            sm_client = get_secretsmanager_client_by_role(probe_role_arn)
+            sm_client = get_secretsmanager_client_by_role(
+                probe_role_arn, test_role_arn, aws_region
+            )
             assert (
                 sm_client.get_secret_value(
                     SecretId="foo",
@@ -257,7 +266,7 @@ def test_module_secret_value(probe_role, keep_after, test_role_arn):
             )
 
 
-def test_module_external_value(probe_role, keep_after, test_role_arn):
+def test_module_external_value(probe_role, keep_after, test_role_arn, aws_region):
     """
     Create a secret, set the value outside of Terraform
     """
@@ -267,11 +276,9 @@ def test_module_external_value(probe_role, keep_after, test_role_arn):
         fp.write(
             dedent(
                 f"""
-                region = "{REGION}"
+                region = "{aws_region}"
                 role_arn = "{test_role_arn}"
-                admins = [
-                    "arn:aws:iam::303467602807:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_422821c726d81c14",
-                ]
+                admins = []
 
                 writers = [
                     "{probe_role_arn}"
@@ -285,7 +292,6 @@ def test_module_external_value(probe_role, keep_after, test_role_arn):
         terraform_module_dir,
         destroy_after=True,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
 
@@ -294,12 +300,13 @@ def test_module_external_value(probe_role, keep_after, test_role_arn):
         terraform_module_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
 
         # secret_value_0 = tf_output["secret_value"]["value"]
-        sm_client = get_secretsmanager_client_by_role(probe_role_arn)
+        sm_client = get_secretsmanager_client_by_role(
+            probe_role_arn, test_role_arn, aws_region
+        )
         assert (
             sm_client.get_secret_value(
                 SecretId="foo",
@@ -317,9 +324,10 @@ def test_module_external_value(probe_role, keep_after, test_role_arn):
             terraform_module_dir,
             destroy_after=not keep_after,
             json_output=True,
-            enable_trace=TRACE_TERRAFORM,
         ):
-            sm_client = get_secretsmanager_client_by_role(probe_role_arn)
+            sm_client = get_secretsmanager_client_by_role(
+                probe_role_arn, test_role_arn, aws_region
+            )
             assert (
                 sm_client.get_secret_value(
                     SecretId="foo",
@@ -328,20 +336,18 @@ def test_module_external_value(probe_role, keep_after, test_role_arn):
             )
 
 
-def test_module_name_prefix(keep_after, test_role_arn):
+def test_module_name_prefix(keep_after, test_role_arn, aws_region):
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "secret")
     with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:
         fp.write(
             dedent(
                 f"""
-                region = "{REGION}"
+                region = "{aws_region}"
                 role_arn = "{test_role_arn}"
                 secret_name = null
                 secret_name_prefix = "some_secret"
 
-                admins = [
-                    "arn:aws:iam::303467602807:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_422821c726d81c14",
-                ]
+                admins = []
                 """
             )
         )
@@ -350,19 +356,20 @@ def test_module_name_prefix(keep_after, test_role_arn):
         terraform_module_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
         assert tf_output["secret_name"]["value"].startswith("some_secret")
 
 
-def test_module_tags(secretsmanager_client, keep_after, test_role_arn):
+def test_module_tags(
+    boto3_session, secretsmanager_client, keep_after, test_role_arn, aws_region
+):
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "secret")
     with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:
         fp.write(
             dedent(
                 f"""
-                region = "{REGION}"
+                region = "{aws_region}"
                 role_arn = "{test_role_arn}"
                 tags = {{
                     tag1: "value1"
@@ -375,12 +382,12 @@ def test_module_tags(secretsmanager_client, keep_after, test_role_arn):
         terraform_module_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
         response = secretsmanager_client.describe_secret(
             SecretId=tf_output["secret_arn"]["value"]
         )
+        sts_client = boto3_session.client("sts", region_name=aws_region)
         assert response["Tags"] == [
             {
                 "Key": "owner",
@@ -408,13 +415,13 @@ def test_module_tags(secretsmanager_client, keep_after, test_role_arn):
             },
             {
                 "Key": "account",
-                "Value": "303467602807",
+                "Value": sts_client.get_caller_identity()["Account"],
             },
         ]
 
 
 def test_module_duplicate_role(
-    probe_role, secretsmanager_client, keep_after, test_role_arn
+    probe_role, secretsmanager_client, keep_after, test_role_arn, aws_region
 ):
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "secret")
     probe_role_arn = probe_role["role_arn"]["value"]
@@ -422,11 +429,10 @@ def test_module_duplicate_role(
         fp.write(
             dedent(
                 f"""
-                region = "{REGION}"
+                region = "{aws_region}"
                 role_arn = "{test_role_arn}"
 
                 admins = [
-                    "arn:aws:iam::303467602807:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_422821c726d81c14",
                     "{test_role_arn}"
                 ]
                 writers = [
@@ -443,10 +449,11 @@ def test_module_duplicate_role(
         terraform_module_dir,
         destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
-        sm_client = get_secretsmanager_client_by_role(probe_role["role_arn"]["value"])
+        sm_client = get_secretsmanager_client_by_role(
+            probe_role["role_arn"]["value"], test_role_arn, aws_region
+        )
 
         # Can read
         assert (


### PR DESCRIPTION
If the IAM Access Analyzer isn't enabled in the accout, the role
AWSServiceRoleForAccessAnalyzer doesn't exist.
This PR skips permissions for the AWSServiceRoleForAccessAnalyzer role
if it doesn't exist.
