### PR TITLE
fix: make cross-account CMK explicit opt-in (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ pip install boto3
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.11, < 7.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | n/a |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 
 ## Modules
 
@@ -161,8 +161,9 @@ pip install boto3
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admins"></a> [admins](#input\_admins) | List of role ARNs that will have all permissions of the secret. | `list(string)` | `null` | no |
+| <a name="input_create_cross_account_cmk"></a> [create\_cross\_account\_cmk](#input\_create\_cross\_account\_cmk) | Whether to create a customer-managed KMS key for cross-account secret access.<br/>Defaults to false: the secret uses the AWS-managed key (aws/secretsmanager),<br/>matching pre-1.2.0 behavior. Set to true when readers/writers live in another<br/>AWS account and need to decrypt the secret, since the AWS-managed key cannot be<br/>shared cross-account.<br/><br/>Note: this is an explicit flag rather than auto-detection because deciding it<br/>from role ARN account IDs requires those ARNs to be known at plan time. When an<br/>ARN is computed in the same apply (e.g. an instance role created alongside the<br/>secret), auto-detection produced an unknown value and broke `terraform apply`<br/>with "Invalid count argument" (#49).<br/><br/>Ignored when kms\_key\_id is set. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Name of environment. | `string` | n/a | yes |
-| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | ARN or ID of a customer-managed KMS key to encrypt the secret.<br/>When null (default), the module auto-creates a CMK if cross-account<br/>role ARNs are detected in admins/readers/writers; otherwise it uses<br/>the AWS-managed key (aws/secretsmanager).<br/>Set this explicitly to use your own CMK for compliance requirements<br/>or custom key policy control. | `string` | `null` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | ARN or ID of a customer-managed KMS key to encrypt the secret.<br/>When null (default), the secret uses the AWS-managed key<br/>(aws/secretsmanager), unless create\_cross\_account\_cmk is true, in which<br/>case the module creates a CMK for cross-account access.<br/>Set this explicitly to use your own CMK for compliance requirements<br/>or custom key policy control. Takes precedence over<br/>create\_cross\_account\_cmk. | `string` | `null` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | A tag owner with this value will be placed on a secret. | `string` | `null` | no |
 | <a name="input_readers"></a> [readers](#input\_readers) | List of role ARNs that will have read permissions of the secret. | `list(string)` | `null` | no |
 | <a name="input_secret_description"></a> [secret\_description](#input\_secret\_description) | The secret description in AWS Secretsmanager. | `string` | n/a | yes |

--- a/docs/cross-account.md
+++ b/docs/cross-account.md
@@ -12,7 +12,7 @@ Cross-account secret access requires three things to be true simultaneously:
 1. **Resource policy** on the secret allows the consumer role (handled by this module
    when you add the consumer role ARN to `writers` or `readers`).
 2. **KMS key policy** on a customer-managed key (CMK) allows the consumer role to
-   decrypt. The module auto-creates this CMK when it detects cross-account role ARNs.
+   decrypt. The module creates this CMK when you set `create_cross_account_cmk = true`.
 3. **Identity policy** on the consumer role in the consumer account grants
    `secretsmanager:GetSecretValue` and `kms:Decrypt` scoped to the owner account's
    resources.
@@ -28,14 +28,14 @@ Throughout the examples below:
 
 ## Owner Account Setup
 
-The owner account (`111111111111`) creates the secret. Just add the consumer role
-ARN to `writers` (or `readers`) — the module detects that the role belongs to a
-different account and auto-creates a CMK with the right key policy:
+The owner account (`111111111111`) creates the secret. Add the consumer role ARN to
+`writers` (or `readers`) and set `create_cross_account_cmk = true` so the module
+provisions a CMK with the right key policy:
 
 ```hcl
 module "shared_secret" {
   source  = "registry.infrahouse.com/infrahouse/secret/aws"
-  version = "1.1.1"
+  version = "1.3.0"
 
   secret_name        = "cross-account-config"
   secret_description = "Configuration shared with the consumer account"
@@ -43,20 +43,63 @@ module "shared_secret" {
   environment        = "production"
   service_name       = "shared-secret"
 
-  writers = ["arn:aws:iam::222222222222:role/secret-consumer"]
+  writers                  = ["arn:aws:iam::222222222222:role/secret-consumer"]
+  create_cross_account_cmk = true
 }
 ```
 
-That's it. The module:
+That's it. With `create_cross_account_cmk = true`, the module:
 
-- Detects that `222222222222` is not the current account
-- Creates a CMK with a key policy granting the consumer role `kms:Decrypt`
-  and `kms:GenerateDataKey*`
+- Creates a CMK with a key policy granting any consumer role in `writers`/`readers`
+  (i.e. ARNs whose account differs from the owner account) `kms:Decrypt` and
+  `kms:GenerateDataKey*`
 - Encrypts the secret with that CMK
 - Generates a resource policy granting the consumer role read/write access
 
+> **Why isn't this auto-detected?** Earlier versions inferred cross-account access by
+> reading the account ID out of each role ARN. That breaks when an ARN is computed in
+> the same apply (e.g. an instance role created alongside the secret): the value is
+> unknown at plan time, so Terraform can't decide whether to create the key and fails
+> with `Invalid count argument`. The explicit flag avoids that entirely. See
+> [issue #49](https://github.com/infrahouse/terraform-aws-secret/issues/49).
+
 The CMK ARN is available via `module.shared_secret.kms_key_id` — the consumer
 account needs it for scoping its identity policy.
+
+!!! warning "The consumer role must exist before you apply the owner side"
+    When `create_cross_account_cmk = true`, the module writes the consumer role
+    ARNs into the **CMK key policy**. AWS KMS validates every principal named in a
+    key policy and rejects ARNs that don't yet exist, so the owner-side apply fails
+    with:
+
+    ```
+    MalformedPolicyDocumentException: Policy contains a statement with
+    one or more invalid principals.
+    ```
+
+    This is a KMS-specific rule — see
+    [PutKeyPolicy](https://docs.aws.amazon.com/kms/latest/APIReference/API_PutKeyPolicy.html).
+    The secret's **resource policy** is *not* affected: it matches the consumer with
+    an `ArnLike` condition on `aws:PrincipalArn`, which is evaluated per request and
+    never requires the role to exist at apply time.
+
+    The practical consequence is an ordering dependency between the two accounts:
+
+    1. The **consumer** account creates the IAM role first and hands over its ARN.
+    2. The **owner** account adds that ARN to `writers`/`readers`, sets
+       `create_cross_account_cmk = true`, and applies.
+
+    If the consumer role is later deleted, subsequent owner-side applies keep failing
+    the same way until the role is recreated or removed from `writers`/`readers`.
+
+!!! note "Grant specific roles, never `:root`"
+    Add the individual consumer role ARNs to `writers`/`readers` rather than the
+    account root (`arn:aws:iam::222222222222:root`). The module scopes both the
+    resource policy and the CMK key policy to exactly those ARNs, following least
+    privilege — this protects the consumer account from a misconfiguration where an
+    unexpected identity in that account gains access to the secret. Granting `:root`
+    would also sidestep the existence check above, but at the cost of exposing the
+    secret to every principal in the consumer account.
 
 !!! note "Bring your own CMK"
     If you need custom key policy settings, create a CMK separately and pass
@@ -205,10 +248,19 @@ Check the resource policy on the secret:
 aws secretsmanager get-resource-policy --secret-id <secret-arn>
 ```
 
+### MalformedPolicyDocumentException: invalid principals (owner-side apply)
+
+The owner-side apply fails while creating or updating the CMK because a consumer
+role ARN in `writers`/`readers` does not exist. KMS refuses to save a key policy
+that names a non-existent principal. Make sure every consumer role exists before
+you apply, then re-run. The secret's resource policy is unaffected because it
+matches `aws:PrincipalArn` with `ArnLike` rather than naming the principal
+directly. See [The consumer role must exist before you apply](#owner-account-setup).
+
 ### KMS AccessDeniedException
 
-The CMK key policy doesn't include the consumer role. If using the
-auto-created CMK, check the key policy:
+The CMK key policy doesn't include the consumer role. Check the key policy on the
+module-created CMK:
 
 ```bash
 aws kms get-key-policy --key-id <key-arn> --policy-name default

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -139,8 +139,8 @@ resource "aws_ecs_task_definition" "worker" {
 
 ## Cross-Account Access
 
-Share a secret with a role in another AWS account. The module auto-creates a
-CMK when it detects cross-account role ARNs.
+Share a secret with a role in another AWS account. Set `create_cross_account_cmk = true`
+so the module creates a CMK the consumer role can use to decrypt.
 See the [Cross-Account Access](cross-account.md) guide for a full walkthrough.
 
 ```hcl
@@ -154,7 +154,8 @@ module "shared_secret" {
   environment        = "production"
   service_name       = "shared-secret"
 
-  writers = ["arn:aws:iam::222222222222:role/secret-consumer"]
+  writers                  = ["arn:aws:iam::222222222222:role/secret-consumer"]
+  create_cross_account_cmk = true
 }
 ```
 

--- a/locals.tf
+++ b/locals.tf
@@ -65,18 +65,6 @@ locals {
     ) : var.readers
   ) : null
 
-  all_role_arns = concat(
-    var.admins == null ? [] : var.admins,
-    var.readers == null ? [] : var.readers,
-    var.writers == null ? [] : var.writers,
-  )
-
-  cross_account_arns = [
-    for arn in local.all_role_arns : arn
-    if can(split(":", arn)[4]) &&
-    split(":", arn)[4] != data.aws_caller_identity.current.account_id
-  ]
-
   cross_account_writers = [
     for arn in concat(
       var.admins == null ? [] : var.admins,
@@ -93,7 +81,14 @@ locals {
     !contains(local.cross_account_writers, arn)
   ]
 
-  create_cmk = length(local.cross_account_arns) > 0 && var.kms_key_id == null
+  # Whether to create a customer-managed KMS key for cross-account access.
+  # This MUST be plan-time-known because it gates module.cross_account_key's count, so
+  # it comes from an explicit flag rather than inspecting role ARNs. Reading the account
+  # ID out of an ARN (split(":", arn)[4]) yields an unknown value when any reader/writer
+  # ARN is computed in the same apply (e.g. an instance role created alongside the
+  # secret), which made count unknown and broke `terraform apply` (#49).
+  # An explicit kms_key_id always wins.
+  create_cmk = var.kms_key_id == null && var.create_cross_account_cmk
 
   effective_kms_key_id = local.create_cmk ? module.cross_account_key[0].kms_key_arn : var.kms_key_id
 }

--- a/test_data/secret_cmk/main.tf
+++ b/test_data/secret_cmk/main.tf
@@ -1,9 +1,10 @@
 module "test" {
-  source             = "../../"
-  secret_description = "Foo CMK description"
-  secret_name        = var.secret_name
-  writers            = [var.consumer_role_arn]
-  secret_value       = var.secret_value
-  environment        = "development"
-  service_name       = "secret-cmk-test"
+  source                   = "../../"
+  secret_description       = "Foo CMK description"
+  secret_name              = var.secret_name
+  writers                  = [var.consumer_role_arn]
+  secret_value             = var.secret_value
+  environment              = "development"
+  service_name             = "secret-cmk-test"
+  create_cross_account_cmk = true
 }

--- a/test_data/secret_computed_arn/.gitignore
+++ b/test_data/secret_computed_arn/.gitignore
@@ -1,0 +1,1 @@
+terraform.tf

--- a/test_data/secret_computed_arn/main.tf
+++ b/test_data/secret_computed_arn/main.tf
@@ -1,0 +1,36 @@
+# Regression coverage for issue #49.
+#
+# The reader is the ARN of an IAM role created in this same apply, so its value is
+# unknown at plan time. Before the fix, the module inspected the account ID inside
+# this ARN to decide whether to create a cross-account CMK, which made
+# module.cross_account_key's count unknown and failed with "Invalid count argument".
+# With create_cross_account_cmk defaulting to false, no ARN inspection gates the
+# count, so plan/apply must succeed.
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "reader" {
+  name_prefix        = "secret-49-reader-"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+module "test" {
+  source             = "../../"
+  secret_description = "Computed-ARN reader regression (#49)"
+  secret_name        = var.secret_name
+  secret_value       = "bar"
+  environment        = "development"
+  service_name       = "secret-computed-arn-test"
+
+  # Unknown at plan time — this is the value that used to break count.
+  readers = [aws_iam_role.reader.arn]
+}

--- a/test_data/secret_computed_arn/outputs.tf
+++ b/test_data/secret_computed_arn/outputs.tf
@@ -1,0 +1,7 @@
+output "secret_arn" {
+  value = module.test.secret_arn
+}
+
+output "kms_key_id" {
+  value = module.test.kms_key_id
+}

--- a/test_data/secret_computed_arn/providers.tf
+++ b/test_data/secret_computed_arn/providers.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = var.region
+  dynamic "assume_role" {
+    for_each = var.role_arn != null ? [1] : []
+    content {
+      role_arn = var.role_arn
+    }
+  }
+  default_tags {
+    tags = {
+      "created_by" : "infrahouse/terraform-aws-secret" # GitHub repository that created a resource
+    }
+
+  }
+}

--- a/test_data/secret_computed_arn/variables.tf
+++ b/test_data/secret_computed_arn/variables.tf
@@ -1,0 +1,7 @@
+variable "region" {}
+variable "role_arn" {
+  default = null
+}
+variable "secret_name" {
+  default = "foo_computed_arn"
+}

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -514,6 +514,37 @@ def test_module_null_secret_value_output(
             )
 
 
+def test_module_computed_reader_arn(keep_after, test_role_arn, aws_region):
+    """
+    Regression test for #49.
+
+    A reader ARN that is computed in the same apply (here, an IAM role created
+    alongside the secret) is unknown at plan time. The module must still plan and
+    apply successfully and fall back to the AWS-managed key, instead of failing with
+    "Invalid count argument" on module.cross_account_key.
+    """
+    terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "secret_computed_arn")
+    with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:
+        fp.write(dedent(f"""
+                region = "{aws_region}"
+                role_arn = "{test_role_arn}"
+                """))
+    init_terraform_tf(terraform_module_dir)
+
+    # Entering the context manager means `terraform apply` succeeded, which is the
+    # behavior #49 broke.
+    with terraform_apply(
+        terraform_module_dir,
+        destroy_after=not keep_after,
+        json_output=True,
+    ) as tf_output:
+        LOG.info("%s", json.dumps(tf_output, indent=4))
+        assert tf_output["secret_arn"]["value"]
+        # No CMK was created: the secret uses the AWS-managed key, so kms_key_id is
+        # null (Terraform omits null outputs from json output entirely).
+        assert not tf_output.get("kms_key_id", {}).get("value")
+
+
 def test_module_duplicate_role(
     probe_role, keep_after, test_role_arn, aws_region, boto3_session
 ):

--- a/variables.tf
+++ b/variables.tf
@@ -68,14 +68,35 @@ variable "service_name" {
 variable "kms_key_id" {
   description = <<-EOT
     ARN or ID of a customer-managed KMS key to encrypt the secret.
-    When null (default), the module auto-creates a CMK if cross-account
-    role ARNs are detected in admins/readers/writers; otherwise it uses
-    the AWS-managed key (aws/secretsmanager).
+    When null (default), the secret uses the AWS-managed key
+    (aws/secretsmanager), unless create_cross_account_cmk is true, in which
+    case the module creates a CMK for cross-account access.
     Set this explicitly to use your own CMK for compliance requirements
-    or custom key policy control.
+    or custom key policy control. Takes precedence over
+    create_cross_account_cmk.
   EOT
   type        = string
   default     = null
+}
+
+variable "create_cross_account_cmk" {
+  description = <<-EOT
+    Whether to create a customer-managed KMS key for cross-account secret access.
+    Defaults to false: the secret uses the AWS-managed key (aws/secretsmanager),
+    matching pre-1.2.0 behavior. Set to true when readers/writers live in another
+    AWS account and need to decrypt the secret, since the AWS-managed key cannot be
+    shared cross-account.
+
+    Note: this is an explicit flag rather than auto-detection because deciding it
+    from role ARN account IDs requires those ARNs to be known at plan time. When an
+    ARN is computed in the same apply (e.g. an instance role created alongside the
+    secret), auto-detection produced an unknown value and broke `terraform apply`
+    with "Invalid count argument" (#49).
+
+    Ignored when kms_key_id is set.
+  EOT
+  type        = bool
+  default     = false
 }
 
 variable "tags" {


### PR DESCRIPTION
## Problem

`terraform apply` fails with `Invalid count argument` whenever a `readers`/`writers` ARN is **computed in the same apply** (e.g. an instance role created alongside the secret). Closes #49.

Root cause: 1.2.0 decided whether to create the cross-account CMK by reading the account ID out of each role ARN (`split(":", arn)[4]`). When an ARN is unknown at plan time, that expression is unknown → `local.create_cmk` is unknown → `module.cross_account_key`'s `count` is unknown, which Terraform forbids. Seen in elasticsearch and kibana CI.

There is no way around this with auto-detection: HCL has no "is this value known yet?" primitive, so a default that inspects ARNs can never be plan-safe.

## Fix

Cross-account CMK creation is now an **explicit opt-in** via a new `create_cross_account_cmk` variable (`bool`, default `false`). `create_cmk` no longer inspects ARNs, so it is always known at plan time.

- **Same-account callers** (everyone currently breaking): upgrade with **zero code changes** — they get the AWS-managed key, exactly the pre-1.2.0 behavior.
- **Cross-account callers**: set `create_cross_account_cmk = true`. An explicit `kms_key_id` still takes precedence.

### Tradeoff

The 1.2.0 "auto-detect cross-account from literal ARNs" magic is gone — it is irreparably incompatible with computed ARNs. Cross-account is now declared, not inferred.

## Docs gap (from a real support thread)

The guide never stated that **consumer role ARNs in the CMK key policy must already exist at apply time** — AWS KMS rejects non-existent principals (`MalformedPolicyDocumentException`), unlike the secret's `ArnLike` resource policy. Added:
- A warning callout spelling out the cross-account ordering (consumer creates role → owner applies) and the contrast with the resource policy.
- A "grant specific roles, never `:root`" least-privilege note.
- A troubleshooting entry for the error.

## Testing

- New regression test `test_module_computed_reader_arn` + `test_data/secret_computed_arn/`: an IAM role created in the same apply is passed as a `reader` (computed ARN) with the default `false`; asserts apply succeeds and falls back to the managed key. Passing locally.
- Updated the existing manual CMK test to set `create_cross_account_cmk = true`.

## Release note

Suggest cutting as **1.3.0** (`make release-minor`) — new variable + changed default behavior for cross-account callers. Docs version pins bumped to 1.3.0 accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)